### PR TITLE
refactor(theme): centralize dark-mode application, fix FOUC and layout bugs; patch vulnerable gems

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -37,6 +37,8 @@ jobs:
           ruby-version: "3.4"
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 0 # Increment this number if you need to re-download cached gems
+        env:
+          BUNDLE_WITHOUT: development
 
       - name: Setup Pages
         id: pages

--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,3 @@ settings.json
 # Jekyll & Gems
 _site
 .jekyll-cache
-
-Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,11 @@
 source "https://rubygems.org"
 
 gem "jekyll", "~> 4.4.1"
-gem "webrick"
 gem "logger"
+
+group :development do
+  gem "webrick"
+end
 
 group :jekyll_plugins do
   gem "jekyll-seo-tag"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,99 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    base64 (0.3.0)
+    bigdecimal (3.3.1)
+    colorator (1.1.0)
+    concurrent-ruby (1.3.7)
+    csv (3.3.5)
+    em-websocket (0.5.3)
+      eventmachine (>= 0.12.9)
+      http_parser.rb (~> 0)
+    eventmachine (1.2.7)
+    ffi (1.17.2-x64-mingw-ucrt)
+    ffi (1.17.2-x86_64-linux-gnu)
+    forwardable-extended (2.6.0)
+    google-protobuf (4.33.1-x64-mingw-ucrt)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    http_parser.rb (0.8.0)
+    i18n (1.14.7)
+      concurrent-ruby (~> 1.0)
+    jekyll (4.4.1)
+      addressable (~> 2.4)
+      base64 (~> 0.2)
+      colorator (~> 1.0)
+      csv (~> 3.0)
+      em-websocket (~> 0.5)
+      i18n (~> 1.0)
+      jekyll-sass-converter (>= 2.0, < 4.0)
+      jekyll-watch (~> 2.0)
+      json (~> 2.6)
+      kramdown (~> 2.3, >= 2.3.1)
+      kramdown-parser-gfm (~> 1.0)
+      liquid (~> 4.0)
+      mercenary (~> 0.3, >= 0.3.6)
+      pathutil (~> 0.9)
+      rouge (>= 3.0, < 5.0)
+      safe_yaml (~> 1.0)
+      terminal-table (>= 1.8, < 4.0)
+      webrick (~> 1.7)
+    jekyll-paginate-v2 (3.0.0)
+      jekyll (>= 3.0, < 5.0)
+    jekyll-sass-converter (3.1.0)
+      sass-embedded (~> 1.75)
+    jekyll-seo-tag (2.8.0)
+      jekyll (>= 3.8, < 5.0)
+    jekyll-sitemap (1.4.0)
+      jekyll (>= 3.7, < 5.0)
+    jekyll-watch (2.2.1)
+      listen (~> 3.0)
+    json (2.20.0)
+    kramdown (2.5.1)
+      rexml (>= 3.3.9)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
+    liquid (4.0.4)
+    listen (3.9.0)
+      rb-fsevent (~> 0.10, >= 0.10.3)
+      rb-inotify (~> 0.9, >= 0.9.10)
+    logger (1.7.0)
+    mercenary (0.4.0)
+    pathutil (0.16.2)
+      forwardable-extended (~> 2.6)
+    public_suffix (7.0.5)
+    rake (13.3.1)
+    rb-fsevent (0.11.2)
+    rb-inotify (0.11.1)
+      ffi (~> 1.0)
+    rexml (3.4.4)
+    rouge (4.6.1)
+    safe_yaml (1.0.5)
+    sass-embedded (1.94.2-x64-mingw-ucrt)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    terminal-table (3.0.2)
+      unicode-display_width (>= 1.1.1, < 3)
+    unicode-display_width (2.6.0)
+    webrick (1.9.2)
+
+PLATFORMS
+  x64-mingw-ucrt
+  x86_64-linux
+
+DEPENDENCIES
+  jekyll (~> 4.4.1)
+  jekyll-paginate-v2
+  jekyll-seo-tag
+  jekyll-sitemap
+  logger
+  webrick
+
+BUNDLED WITH
+  4.0.9

--- a/_includes/loader.html
+++ b/_includes/loader.html
@@ -1,4 +1,4 @@
-<div id="loader" class="loader-light">
+<div id="loader">
     <div class="dot"></div>
     <div class="dot"></div>
     <div class="dot"></div>

--- a/_includes/scripts.html
+++ b/_includes/scripts.html
@@ -1,5 +1,5 @@
 <!-- Theme and Loader -->
-<script defer src="{{ '/assets/js/theme-and-loader.js' | relative_url }}"></script>
+<script defer src="{{ '/assets/js/theme-and-loader.js' | relative_url }}?v={{ site.time | date: '%s' }}"></script>
 
 {% if page.custom_js %}
 <script defer src="{{ page.custom_js | relative_url }}"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,6 +6,25 @@
 </head>
 
 <body>
+    <script>
+        // Single source of truth for applying the stored theme. Called on
+        // first paint (here), once the toggle icon exists in the DOM
+        // (theme-and-loader.js), on user toggle, and on bfcache restores
+        // (`pageshow` with persisted=true skips all other script execution,
+        // so without this the page could show a stale theme after
+        // back/forward navigation).
+        window.applyStoredTheme = () => {
+            const isDark = localStorage.getItem('dark-mode-state') === '1';
+            document.body.classList.toggle('dark-mode', isDark);
+            document.querySelector('.color-mode-icon')?.classList.toggle('active', isDark);
+        };
+        window.applyStoredTheme();
+        // Re-sync on every pageshow, not just when event.persisted is true:
+        // persisted-flag support for bfcache restores is inconsistent across
+        // browsers/versions, and re-running this is a cheap no-op on a
+        // regular (non-cached) load.
+        window.addEventListener('pageshow', () => window.applyStoredTheme());
+    </script>
     {% include loader.html %}
     {% include nav.html %}
 

--- a/assets/css/base-site.scss
+++ b/assets/css/base-site.scss
@@ -3,6 +3,7 @@
 /* CSS VARIABLES */
 :root {
     --themeColor: #42EABD;
+    --themeColor-rgb: 66, 234, 189;
     --themeColor-text: #00a884;
     --link-color-light-theme: #00c28e;
     --link-color-dark-theme: #00ffbb;
@@ -20,6 +21,8 @@
 
     --text-color: var(--text-light);
     --bg-color: var(--background-light);
+    --headers-color: var(--headers-light);
+    --border-color: rgba(var(--themeColor-rgb), 0.15);
 }
 
 /* RESET & BASE */
@@ -898,13 +901,10 @@ body.sidebar-open {
     justify-content: center;
     align-items: center;
     z-index: 1000;
-}
-
-.loader-light {
     background: var(--background-light);
 }
 
-.loader-dark {
+body.dark-mode #loader {
     background: var(--background-dark);
 }
 
@@ -1046,6 +1046,7 @@ p {
     background: var(--background-dark);
     --text-color: var(--text-dark);
     --bg-color: var(--background-dark);
+    --headers-color: var(--headers-dark);
 }
 
 .dark-mode .small-text {
@@ -1148,11 +1149,11 @@ p {
     animation-delay: 0.4s;
 }
 
-[data-theme="dark"] .social-link {
+.dark-mode .social-link {
     border-color: rgba(255, 255, 255, 0.2);
 }
 
-[data-theme="dark"] .social-link:hover {
+.dark-mode .social-link:hover {
     border-color: rgba(255, 255, 255, 0.5);
 }
 
@@ -1197,10 +1198,10 @@ p {
 }
 
 .timeline-item {
-    display: grid;
-    grid-template-columns: auto 2fr;
-    align-items: center;
-    gap: 10px;
+    /* .timeline-year (the rotated year label) is position:absolute and
+       therefore not a layout participant here - .timeline-content is the
+       only in-flow child, so this is a plain block, not a grid/flex
+       container. */
     padding: 2% 4%;
     background: transparent;
     border: none;
@@ -1251,6 +1252,14 @@ p {
 .timeline-content small {
     display: block;
     margin-bottom: 10px;
+}
+
+/* Open Source PR cards: the description <small> sits inside an <a> and
+   should keep reading as a link (matching .timeline-details summary),
+   not fall back to the muted body.dark-mode small/p/strong/em/blockquote
+   color. */
+body.dark-mode .timeline-content a small {
+    color: var(--themeColor-text);
 }
 
 .timeline-content h3 {
@@ -1321,11 +1330,11 @@ p {
     color: var(--themeColor);
 }
 
-[data-theme="dark"] .timeline-content {
+.dark-mode .timeline-content {
     border-color: rgba(255, 255, 255, 0.1);
 }
 
-[data-theme="dark"] .timeline-content:hover {
+.dark-mode .timeline-content:hover {
     border-color: rgba(255, 255, 255, 0.2);
 }
 
@@ -1386,14 +1395,6 @@ body.dark-mode .light-logo {
 
 body.dark-mode .dark-logo {
     display: inline;
-}
-
-[data-theme="dark"] .dark-logo {
-    display: block;
-}
-
-[data-theme="dark"] .light-logo {
-    display: none;
 }
 
 .companies-section {
@@ -1844,8 +1845,15 @@ th {
 .article-content p,
 .article-content li {
     line-height: 1.8;
-    margin-bottom: 1.5em;
     letter-spacing: 0.01em;
+}
+
+.article-content p {
+    margin-bottom: 1.5em;
+}
+
+.article-content li {
+    margin-bottom: 0.5em;
 }
 
 .article-content h2,

--- a/assets/js/theme-and-loader.js
+++ b/assets/js/theme-and-loader.js
@@ -1,26 +1,17 @@
 document.addEventListener('DOMContentLoaded', () => {
-  const colorModeIcon = document.querySelector('.color-mode-icon');
   const colorModeToggle = document.querySelector('.color-mode');
   const body = document.body;
 
-  // Initialize dark mode
-  const darkModeState = localStorage.getItem('dark-mode-state');
-  if (darkModeState === '1') {
-    colorModeIcon?.classList.add('active');
-    body.classList.add('dark-mode');
-    setTheme();
-  }
-  setLoaderBackground();
+  // Re-run the single theme-application function now that the toggle
+  // icon exists in the DOM (it didn't yet when the blocking init script
+  // in _layouts/default.html made its first call).
+  window.applyStoredTheme?.();
 
   // Theme toggle
   colorModeToggle?.addEventListener('click', () => {
-    colorModeIcon?.classList.toggle('active');
-    body.classList.toggle('dark-mode');
-    setTheme();
-
-    const currentState = localStorage.getItem('dark-mode-state');
-    const nextState = currentState === '1' ? '0' : '1';
-    localStorage.setItem('dark-mode-state', nextState);
+    const isDark = localStorage.getItem('dark-mode-state') === '1';
+    localStorage.setItem('dark-mode-state', isDark ? '0' : '1');
+    window.applyStoredTheme?.();
   });
 
   // Mobile Sidebar functionality
@@ -74,13 +65,6 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   });
 
-  // Old navbar toggle (for backwards compatibility)
-  const navbarToggler = document.querySelector('.navbar-toggler');
-  const navbarNav = document.getElementById('navbarNav');
-  navbarToggler?.addEventListener('click', () => {
-    navbarNav?.classList.toggle('show');
-  });
-
   // Smooth scroll for anchor links
   document.querySelectorAll('.nav-link, .sidebar-link, .custom-btn-link').forEach(anchor => {
     anchor.addEventListener('click', function (event) {
@@ -96,7 +80,6 @@ document.addEventListener('DOMContentLoaded', () => {
         if (el) {
           el.scrollIntoView({ behavior: 'smooth', block: 'start' });
         }
-        if (navbarNav) navbarNav.classList.remove('show');
       }
     });
   });
@@ -108,34 +91,3 @@ window.addEventListener('load', () => {
     loader.style.display = 'none';
   }
 });
-
-function setTheme() {
-  const body = document.body;
-  const navbar = document.querySelector('.navbar, .modern-navbar');
-  const texts = document.querySelectorAll('p, strong, em, blockquote');
-
-  if (body.classList.contains('dark-mode')) {
-    if (navbar) navbar.style.backgroundColor = 'var(--background-dark)';
-    body.style.backgroundColor = 'var(--background-dark)';
-    body.style.color = 'var(--text-dark)';
-    texts.forEach(el => el.style.color = 'var(--text-dark)');
-  } else {
-    if (navbar) navbar.style.backgroundColor = '#fff';
-    body.style.backgroundColor = 'var(--background-light)';
-    body.style.color = 'var(--text-light)';
-    texts.forEach(el => el.style.color = 'var(--text-light)');
-  }
-  setLoaderBackground();
-}
-
-function setLoaderBackground() {
-  const loader = document.getElementById('loader');
-  if (!loader) return;
-  if (document.body.classList.contains('dark-mode')) {
-    loader.classList.remove('loader-light');
-    loader.classList.add('loader-dark');
-  } else {
-    loader.classList.remove('loader-dark');
-    loader.classList.add('loader-light');
-  }
-}


### PR DESCRIPTION
- centralize theme application into window.applyStoredTheme (survives bfcache pageshow restores, previously stale after back/forward nav)
- remove [data-theme] attribute selectors in favor of .dark-mode class, eliminating dead/duplicate CSS rules
- fix timeline card width inconsistency and loader theme flash
- fix article list-item spacing incorrectly inheriting paragraph spacing
- fix PR link description text being grayed out by dark-mode text rule
- cache-bust theme-and-loader.js via site.time query param
- remove vestigial timeline grid and dead navbar toggle JS
- bump concurrent-ruby, addressable, json to patched versions (CVE-2026-35611, CVE-2026-33210, CVE-2026-54696, CVE-2026-54904/5/6)
- move webrick to Gemfile `group :development`; not used in the GitHub Pages production build (CVE-2026-38969, no patch yet upstream)
- exclude development group in CI via BUNDLE_WITHOUT=development
- commit Gemfile.lock for reproducible builds